### PR TITLE
Do not fail if state is not started

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,3 +56,4 @@
     return_content: true
   register: metrics_output
   failed_when: "'Metrics' not in metrics_output.content"
+  when: node_exporter_state == "started"


### PR DESCRIPTION
When using node_exporter_state stopped the role will fail,
while nodeexporter is expected to not respond.